### PR TITLE
Adding package.json for easier npm install command

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -17,7 +17,7 @@ h2. To use:
 
 git clone https://github.com/mozilla/mortar.git
 cd mortar
-npm install ejs
+npm install
 ./bin/build app-stub my-app-stub
 
 h2. How does it work?

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "mortar",
+  "version": "0.0.1",
+  "dependencies": {
+    "ejs": "0.7.2"
+  }
+}


### PR DESCRIPTION
A minor tweak, but might be useful if more node dependencies enter the project.

Install becomes as easy as:

```
npm install
```

instead of 

```
npm install ejs
```
