### PR TITLE
Css import fix

### DIFF
--- a/default-project/www/css/app.css
+++ b/default-project/www/css/app.css
@@ -1,4 +1,4 @@
 
-@import "defaults.css"
+@import "defaults.css";
 
 /* Your styles here */

--- a/ref/app-stub/www/css/app.css
+++ b/ref/app-stub/www/css/app.css
@@ -1,4 +1,4 @@
 
-@import "defaults.css"
+@import "defaults.css";
 
 /* Your styles here */


### PR DESCRIPTION
As is, app.css won't cause defaults.css to be downloaded in Aurora.
Also, not sure if we should use `@import url("defaults.css");` syntax instead of the bare string.
