### PR TITLE
Fix missing double-quotes in header template.

### DIFF
--- a/templates/app-stub/head.html
+++ b/templates/app-stub/head.html
@@ -4,9 +4,9 @@
     <!-- <link rel="stylesheet" href="css/bootstrap-responsive.css"> -->
     
     <!-- x-tags: https://github.com/csuwldcat/x-tag -->
-    <!-- <script src="js/lib/x-tag.js></script> -->
+    <!-- <script src="js/lib/x-tag.js"></script> -->
 
     <!-- For x-tags, you need to include each component's style and js
          here, for example for the accordion: -->
     <!-- <link rel="stylesheet" href="css/lib/x-tag/accordion.css"> -->
-    <!-- <script src="js/lib/x-tag/accordion.js></script> -->
+    <!-- <script src="js/lib/x-tag/accordion.js"></script> -->


### PR DESCRIPTION
Noticed there were missing quotes from the header template.
